### PR TITLE
[ZEN-4504] Roll back shared RAPID-ML Parser to Xtext 2.9.1 (DO NOT MERGE)

### DIFF
--- a/com.reprezen.rapidml.model/pom.xml
+++ b/com.reprezen.rapidml.model/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>2.9.2</version>
+			<version>${xtextVersion}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <url>http://rapid-api.org/rapid-ml/index.html</url>
     
     <properties>
-	<xtextVersion>2.9.2</xtextVersion>
+	<xtextVersion>2.9.1</xtextVersion>
 	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	<maven.compiler.source>1.8</maven.compiler.source>
 	<maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
I'm not so sure that 2.9.2 was such a different release than 2.9.1. The Xtext [release notes ](https://www.eclipse.org/Xtext/releasenotes.html#/releasenotes/2015/11/16/version-2-9-0) does not mention it. Looks like 2.9.0 contains the significant changes with the introduction of maven support and the new Xtext code generator.  We are using the new code generator in this project because it is the one that came with the maven support. RAPID-ML in API Studio is using the previous code generator. This is why we have different configuration in the `mwe2` files. 

I could not make our old `mwe2` configuration with maven, so I updated it to the new one. Maybe it can be doable if we don't rely on maven to call the generator but instead invoke it from eclipse and add the generated sources to this repository. 

@tedepstein @andylowry What do you think? Should we roll back also to the old generator?
