### PR TITLE
[ZEN-4688] API Studio started failing to build, problem with xtend-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 				<plugin>
 					<groupId>org.eclipse.xtend</groupId>
 					<artifactId>xtend-maven-plugin</artifactId>
-					<version>${xtextVersion}</version>
+					<version>2.15.0</version>
 					<executions>
 						<execution>
 							<goals>


### PR DESCRIPTION
Update to xtend maven plugin 2.15 to avoid build failures.