### PR TITLE
[ZEN-4770] Suggestion to use fixed versions for transitive dependencies in GenTarget POMs

### DIFF
--- a/com.reprezen.rapidml.model/pom.xml
+++ b/com.reprezen.rapidml.model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.reprezen.rapidml</groupId>
 		<artifactId>com.reprezen.rapidml.parent</artifactId>
-		<version>0.0.10-ZEN-4770-SNAPSHOT</version>
+		<version>0.0.10-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<dependencies>

--- a/com.reprezen.rapidml.realization/pom.xml
+++ b/com.reprezen.rapidml.realization/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.reprezen.rapidml</groupId>
 		<artifactId>com.reprezen.rapidml.parent</artifactId>
-		<version>0.0.10-ZEN-4770-SNAPSHOT</version>
+		<version>0.0.10-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<dependencies>

--- a/com.reprezen.rapidml/pom.xml
+++ b/com.reprezen.rapidml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.reprezen.rapidml</groupId>
 		<artifactId>com.reprezen.rapidml.parent</artifactId>
-		<version>0.0.10-ZEN-4770-SNAPSHOT</version>
+		<version>0.0.10-SNAPSHOT</version>
 	</parent>	
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.reprezen.rapidml</groupId>
 	<artifactId>com.reprezen.rapidml.parent</artifactId>
-	<version>0.0.10-ZEN-4770-SNAPSHOT</version>
+	<version>0.0.10-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>RAPID-ML</name>
 	<description>Parser and Model for RAPID-ML modeling language</description>
@@ -311,12 +311,12 @@
 			<dependency>
 				<groupId>com.reprezen.rapidml</groupId>
 				<artifactId>com.reprezen.rapidml.model</artifactId>
-				<version>0.0.10-ZEN-4770-SNAPSHOT</version>
+				<version>0.0.10-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>com.reprezen.rapidml</groupId>
 				<artifactId>com.reprezen.rapidml.realization</artifactId>
-				<version>0.0.10-ZEN-4770-SNAPSHOT</version>
+				<version>0.0.10-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.xtend</groupId>


### PR DESCRIPTION
Remove version ranges for EMF and update to latest JsonOverlay.

See https://github.com/RepreZen/GenFlow/pull/55