### PR TITLE
[ZEN-4707] GenFlow: Upgrade to SCG 2.4.4 to address SCG Kotlin Server codegen failure - DO NOT MERGE

### DIFF
--- a/com.reprezen.rapidml.model/pom.xml
+++ b/com.reprezen.rapidml.model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.reprezen.rapidml</groupId>
 		<artifactId>com.reprezen.rapidml.parent</artifactId>
-		<version>0.0.10-SNAPSHOT</version>
+		<version>0.0.10-ZEN-4707-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<dependencies>

--- a/com.reprezen.rapidml.realization/pom.xml
+++ b/com.reprezen.rapidml.realization/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.reprezen.rapidml</groupId>
 		<artifactId>com.reprezen.rapidml.parent</artifactId>
-		<version>0.0.10-SNAPSHOT</version>
+		<version>0.0.10-ZEN-4707-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<dependencies>

--- a/com.reprezen.rapidml/pom.xml
+++ b/com.reprezen.rapidml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.reprezen.rapidml</groupId>
 		<artifactId>com.reprezen.rapidml.parent</artifactId>
-		<version>0.0.10-SNAPSHOT</version>
+		<version>0.0.10-ZEN-4707-SNAPSHOT</version>
 	</parent>	
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.reprezen.rapidml</groupId>
 	<artifactId>com.reprezen.rapidml.parent</artifactId>
-	<version>0.0.10-SNAPSHOT</version>
+	<version>0.0.10-ZEN-4707-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>RAPID-ML</name>
 	<description>Parser and Model for RAPID-ML modeling language</description>
@@ -312,12 +312,12 @@
 			<dependency>
 				<groupId>com.reprezen.rapidml</groupId>
 				<artifactId>com.reprezen.rapidml.model</artifactId>
-				<version>0.0.10-SNAPSHOT</version>
+				<version>0.0.10-ZEN-4707-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>com.reprezen.rapidml</groupId>
 				<artifactId>com.reprezen.rapidml.realization</artifactId>
-				<version>0.0.10-SNAPSHOT</version>
+				<version>0.0.10-ZEN-4707-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.xtend</groupId>


### PR DESCRIPTION
Updated the pom file version with the jira number

PS https://github.com/RepreZen/GenFlow/pull/59